### PR TITLE
fixed misspelling of "laod" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ This is a simple prefab that is essentially just a visual preview to show where 
 
 ## Loading Zones
 
-If you want to break up your map into multiple scenes, you can use the `ZoneLaodTigger` prefab to load and unload those scenes.
+If you want to break up your map into multiple scenes, you can use the `ZoneLoadTigger` prefab to load and unload those scenes.
 
 ### Multi Map Setup
 ALL scenes you want included in your map need to be added to the `Scenes In Build` section of the `Build Settings` window.


### PR DESCRIPTION
on line 281 of README.md, there is a misspelling of "LoadZoneSettings"